### PR TITLE
Change can't to cannot to be more formal

### DIFF
--- a/views/tag/view.ejs
+++ b/views/tag/view.ejs
@@ -39,7 +39,7 @@
 	<%
 
 		var body = {};
-		body.prohibited = "This tag can't have a body.";
+		body.prohibited = "This tag cannot have a body.";
 		body.free = "This tag may have a body.";
 		body.required = "This tag must have a body.";
 	%>


### PR DESCRIPTION
In tag documentation template and reference to tags that cannot have a body.
