### PR TITLE
Add camel casing via XML to function list and json for readability

### DIFF
--- a/jsongen.cfm
+++ b/jsongen.cfm
@@ -3,6 +3,7 @@ param name="url.exportPath" default="#expandPath("/export")#";
 
 	sep = SERVER.separator.file;
 	version=  SERVER.lucee.version;
+	xml_funlib=xmlParse('https://bitbucket.org/lucee/lucee/raw/dc1337abc3592eb16b59cb8c93e1bb7083e9d395/lucee-java/lucee-core/src/resource/fld/web-cfmfunctionlibrary_1_0')['func-lib'];
 		
 	
 	
@@ -56,12 +57,19 @@ param name="url.exportPath" default="#expandPath("/export")#";
 	funclist = [];
 	taglist = [];
 	
-
-
+	
 	for(fun in getFunctionList()){
-
-		funclist.append(fun);
+		xml_fun=xmlSearch(xml_funlib,"./function[translate(name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = '#fun#']");
+		//get our function data before we deal with casing
 		fundata = getFunctionData(fun);
+		//use our camel cased function name if it it exists for the remainder of our operations
+		if(arrayLen(xml_fun)){
+			fun=xml_fun[1].name.xmlText;
+			//lowercase our first letter for consistency
+			fun=replace(fun,left(fun,1),lcase(left(fun,1)),'one');
+			fundata.name=fun;
+		}
+		funclist.append(fun);
 		funcPath = FuncsPath & "#sep##fun#.json";
 		//handle our CDATA tab characters after line breaks or our markdown is interpreted as a code block
 		if(structKeyExists(fundata,'description'))


### PR DESCRIPTION
since getFunctionList() and getFunctionData(fun) both return a lower case function name, I've added a remote call at the beginning of JSON generation to pull the XML definitions and use the camel cased name of the function for readability in the function list and definition views.
